### PR TITLE
chore(deps): bump rand to 0.10 in /rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -102,6 +102,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -320,14 +340,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
+ "rand_core",
 ]
 
 [[package]]
@@ -501,15 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,38 +540,26 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -751,15 +750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,12 +849,6 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "z3"

--- a/rust/findchars-bench/Cargo.toml
+++ b/rust/findchars-bench/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 findchars.workspace = true
 findchars-csv.workspace = true
-rand = "0.9"
+rand = "0.10"
 regex = "1"
 
 [dev-dependencies]

--- a/rust/findchars-bench/src/lib.rs
+++ b/rust/findchars-bench/src/lib.rs
@@ -1,7 +1,7 @@
 //! Benchmark utilities: deterministic data generators for findchars benchmarks.
 
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 /// Generate benchmark data with a target match density.
 ///

--- a/rust/findchars/Cargo.toml
+++ b/rust/findchars/Cargo.toml
@@ -12,4 +12,4 @@ thiserror.workspace = true
 findchars-solver.workspace = true
 
 [dev-dependencies]
-rand = "0.9"
+rand = "0.10"

--- a/rust/findchars/tests/fuzz_parity_test.rs
+++ b/rust/findchars/tests/fuzz_parity_test.rs
@@ -11,7 +11,7 @@
 use findchars::{BuildResult, EngineBuilder, MatchStorage, SimdBackend};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 /// SIMD backends the host CPU actually supports — scalar plus whatever the
 /// architecture provides. Requesting an unsupported backend would execute


### PR DESCRIPTION
Addresses one of the two bumps deferred in #72 (the other, z3 0.20, follows in a separate PR).

## Change
`rand` 0.9 → 0.10. The only breaking change touching this repo is the trait rename: the user-level convenience methods (`random`, `random_range`, `random_bool`, …) moved from `Rng` to a new `RngExt` trait. Switched the two import sites (`findchars-bench/src/lib.rs`, `findchars/tests/fuzz_parity_test.rs`) from `Rng` to `RngExt`; every call expression is unchanged.

`StdRng` is now backed by the `chacha20` crate — seeded sequences may differ, which is harmless: `fuzz_parity_test` is a SIMD-vs-oracle parity property test, not a golden-value test.

## Verification (local)
- `cargo build --workspace` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p findchars -p findchars-csv` ✓ (compiles + runs the fuzz test via `RngExt`)